### PR TITLE
 feat: add function to set random seed for reproducibility

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,0 +1,14 @@
+import numpy as np
+import random
+
+import torch
+
+
+def set_seed(seed):
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    np.random.seed(seed)
+    random.seed(seed)


### PR DESCRIPTION
  ## 변경 내용
- `utils` 디렉토리와 utils.py 파일을 추가했습니다
- 재현성을 보장하기 위해 `set_seed` 함수를 추가했습니다
  - `torch.manual_seed(seed)`: PyTorch의 CPU 시드 설정
  - `torch.cuda.manual_seed(seed)`, `torch.cuda.manual_seed_all(seed)`: PyTorch의 GPU 시드 설정
  - `torch.backends.cudnn.deterministic = True`, `torch.backends.cudnn.benchmark = False`: CuDNN 백엔드를 결정적으로 설정
  - `np.random.seed(seed)`: Numpy 시드 설정
  - `random.seed(seed)`: Python의 random 모듈 시드 설정